### PR TITLE
Fix typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,18 +26,18 @@ With the ``keep_geometry`` argument, you can have the method return a geojson-li
 There are similar methods for block groups
 ::
 
-    old_home_block_groups = c.acs5.state_place_blockgroups(('NAME', 'B25034_010E'), 17, 14000))
+    old_home_block_groups = c.acs5.state_place_blockgroup(('NAME', 'B25034_010E'), 17, 14000))
 
 And blocks. Not that block level geographies are only available for the short-form data from the Decennial Census
 ::
   
-    owner_occupied = c.sf1.state_place_blocks(('NAME', 'H016F0002'), 17, 14000)
+    owner_occupied = c.sf1.state_place_block(('NAME', 'H016F0002'), 17, 14000)
 
 The tract and blockgroup methods are also available for the Decennial Census.
 ::
 
     owner_occupied_blockgroup = c.sf1.state_place_tract(('NAME', 'H016F0002'), 17, 14000)
-    owner_occupied_tract = c.sf1.state_place_blockgroups(('NAME', 'H016F0002'), 17, 14000)
+    owner_occupied_tract = c.sf1.state_place_blockgroup(('NAME', 'H016F0002'), 17, 14000)
     
     old_homes = c.sf3.state_place_tract('NAME', 'H034010'), 17, 14000)
     old_homes = c.sf3.state_place_blockgroup('NAME', 'H034010'), 17, 14000)
@@ -58,15 +58,15 @@ In addition to these convenient methods, there are three lower level ways to get
     my_shape_with_new_data_geojson = {'type': "FeatureCollection", 'features': features}
     
 
-The method takes in the census variables you want and a geojson geometry, and returns a **generator** of the tract shapes, as geojson features, and the variables for that tract. You have to figure out what to do with. In the example above, we make a new geojson object.
+The method takes in the census variables you want and a geojson geometry, and returns a **generator** of the tract shapes, as geojson features, and the variables for that tract. You have to figure out what to do with it. In the example above, we make a new geojson object.
 
 Similar methods are provided for block groups and blocks, for the ACS 5-year and Decennial Census.
 ::
 
     c.acs5.geo_blockgroup(('NAME', 'B25034_010E'), my_shape_geojson['geometry'])
     
-    c.sf1.geo_blocks(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
-    c.sf1.geo_blockgroups(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
+    c.sf1.geo_block(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
+    c.sf1.geo_blockgroup(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
     c.sf1.geo_tract(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
     
     c.sf3.state_place_tract('NAME', 'H034010'), my_shape_geojson['geometry'])

--- a/census_area/__init__.py
+++ b/census_area/__init__.py
@@ -150,7 +150,7 @@ class ACS5Client(census.core.ACS5Client, GeoClient):
 
     @supported_years(2014, 2013, 2010)
     def state_place_tract(self, *args, **kwargs):
-        return self._state_place_area(self,geo_tract, *args, **kwargs)
+        return self._state_place_area(self.geo_tract, *args, **kwargs)
 
     @supported_years(2014, 2013, 2010)
     def state_place_blockgroup(self, *args, **kwargs):
@@ -159,7 +159,7 @@ class ACS5Client(census.core.ACS5Client, GeoClient):
 class SF1Client(census.core.SF1Client, GeoClient):
     @supported_years(2010, 2000)
     def state_place_tract(self, *args, **kwargs):
-        return self._state_place_area(self,geo_tract, *args, **kwargs)
+        return self._state_place_area(self.geo_tract, *args, **kwargs)
 
     @supported_years(2010, 2000)
     def state_place_blockgroup(self, *args, **kwargs):

--- a/census_area/__init__.py
+++ b/census_area/__init__.py
@@ -196,7 +196,7 @@ class SF1Client(census.core.SF1Client, GeoClient):
 class SF3Client(census.core.SF3Client, GeoClient):
     @supported_years(2000)
     def state_place_tract(self, *args, **kwargs):
-        return self._state_place_area(self,geo_tract, *args, **kwargs)
+        return self._state_place_area(self.geo_tract, *args, **kwargs)
 
     @supported_years(2000)
     def state_place_blockgroup(self, *args, **kwargs):


### PR DESCRIPTION
A pull request is maybe overkill for this, but I don't have admin access to the repo and you should probably double-check my changes anyway.

I was working through the documentation and found a few small typos in the `README` and `init` files that caused errors when I tried to send queries. In detail:

- A few lines of sample code in the docs had pluralized methods instead of the correct singular (for example, `state_place_blockgroups` instead of `state_place_blockgroup`). I suspect these were copy/pasted since they showed up in a couple different spots. I touched them all up, and fixed another small stylistic typo in the descriptive text where a word was missing.

- A few methods in `SF1Client` and `SF3Client` had a fatal typo when referring to the `geo_tract` attribute, misspelling it as `self,geo_tract`.

Again, small changes, but they seem important.