### PR TITLE
Deprecate SF3Client, update available years for remaining SF1 and ACS5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,8 @@ The tract and blockgroup methods are also available for the Decennial Census.
     owner_occupied_blockgroup = c.sf1.state_place_tract(('NAME', 'H016F0002'), 17, 14000)
     owner_occupied_tract = c.sf1.state_place_blockgroup(('NAME', 'H016F0002'), 17, 14000)
     
-    old_homes = c.sf3.state_place_tract('NAME', 'H034010'), 17, 14000)
-    old_homes = c.sf3.state_place_blockgroup('NAME', 'H034010'), 17, 14000)
+    old_homes = c.sf1.state_place_tract('NAME', 'H034010'), 17, 14000)
+    old_homes = c.sf1.state_place_blockgroup('NAME', 'H034010'), 17, 14000)
 
 In addition to these convenient methods, there are three lower level ways to get census tracts, blocks, and groups for arbitrary geometries.
 
@@ -79,8 +79,8 @@ Similar methods are provided for block groups and blocks, for the ACS 5-year and
     c.sf1.geo_blockgroup(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
     c.sf1.geo_tract(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
     
-    c.sf3.state_place_tract('NAME', 'H034010'), my_shape_geojson['geometry'])
-    c.sf3.state_place_blockgroup('NAME', 'H034010'), my_shape_geojson['geometry'])
+    c.sf1.state_place_tract('NAME', 'H034010'), my_shape_geojson['geometry'])
+    c.sf1.state_place_blockgroup('NAME', 'H034010'), my_shape_geojson['geometry'])
 
 Team
 ====

--- a/census_area/__init__.py
+++ b/census_area/__init__.py
@@ -157,25 +157,25 @@ class ACS5Client(census.core.ACS5Client, GeoClient):
     def state_place_tract(self, *args, **kwargs):
         return self._state_place_area(self.geo_tract, *args, **kwargs)
 
-    @supported_years(2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010)
+    @supported_years(2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010)
     def state_place_blockgroup(self, *args, **kwargs):
         return self._state_place_area(self.geo_blockgroup, *args, **kwargs)
 
 
 class SF1Client(census.core.SF1Client, GeoClient):
-    @supported_years(2010, 2000, 1990)
+    @supported_years(2010)
     def state_place_tract(self, *args, **kwargs):
         return self._state_place_area(self.geo_tract, *args, **kwargs)
 
-    @supported_years(2010, 2000)
+    @supported_years(2010)
     def state_place_blockgroup(self, *args, **kwargs):
         return self._state_place_area(self.geo_blockgroup, *args, **kwargs)
 
-    @supported_years(2010, 2000)
+    @supported_years(2010)
     def state_place_block(self, *args, **kwargs):
         return self._state_place_area(self.geo_block, *args, **kwargs)
 
-    @supported_years(2010, 2000)
+    @supported_years(2010)
     def geo_block(self, fields, geojson_geometry, year):
         if year is None:
             year = self.default_year
@@ -200,16 +200,6 @@ class SF1Client(census.core.SF1Client, GeoClient):
                 result = {}
 
             yield block, result, intersection_proportion
-            
-
-class SF3Client(census.core.SF3Client, GeoClient):
-    @supported_years(2000, 1990)
-    def state_place_tract(self, *args, **kwargs):
-        return self._state_place_area(self.geo_tract, *args, **kwargs)
-
-    @supported_years(2000)
-    def state_place_blockgroup(self, *args, **kwargs):
-        return self._state_place_area(self.geo_blockgroup, *args, **kwargs)
 
 
 class Census(census.Census):
@@ -217,5 +207,3 @@ class Census(census.Census):
         super(Census, self).__init__(key, year, session)
         self.acs5 = ACS5Client(key, year, session)
         self.sf1 = SF1Client(key, year, session)
-        self.sf3 = SF3Client(key, year, session)
-


### PR DESCRIPTION
## Description

The 1990 and 2000 Decennial Census data was removed from the Census API. Accordingly, we also removed it from `census` core in [this commit](https://github.com/datamade/census/commit/2638bab69d3cdb6f5d784e80f9cb543ce738aea7). This PR removes references to the now-deprecated `SF3Client` from this package and updates the documentation accordingly. It also updates the supported years for the `SF1Client` and `ACS5Client`.

Closes #8.