### PR TITLE
Swap map server for 2019 ACS, patch missing HashDict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+census_area.egg-info/
+census_area/__pycache__/

--- a/README.rst
+++ b/README.rst
@@ -22,10 +22,10 @@ Usage
 
     c = Census("MY_API_KEY")
     old_homes = c.acs5.state_place_tract(('NAME', 'B25034_010E'), 17, 14000)
-    
+
 The call above will return the name of the census tract and the number of homes that were built before 1939 for every tract in the City of Chicago. ``17`` is the FIPS code for Illinois and ``14000`` is the FIPS code for Chicago.
 
-By default, this method will return a list of dictionaries, where each dictionary represents the data for one tract. 
+By default, this method will return a list of dictionaries, where each dictionary represents the data for one tract.
 
 With the ``return_geometry`` argument, you can have the method return a geojson-like dictionary. Each tract is a feature, and the census variables about the tract appear in the feature's property attributes.
 ::
@@ -39,7 +39,7 @@ There are similar methods for block groups
 
 And blocks. Note that block level geographies are only available for the short-form data from the Decennial Census
 ::
-  
+
     owner_occupied = c.sf1.state_place_block(('NAME', 'H016F0002'), 17, 14000)
 
 The tract and blockgroup methods are also available for the Decennial Census.
@@ -47,16 +47,16 @@ The tract and blockgroup methods are also available for the Decennial Census.
 
     owner_occupied_blockgroup = c.sf1.state_place_tract(('NAME', 'H016F0002'), 17, 14000)
     owner_occupied_tract = c.sf1.state_place_blockgroup(('NAME', 'H016F0002'), 17, 14000)
-    
+
     old_homes = c.sf1.state_place_tract('NAME', 'H034010'), 17, 14000)
     old_homes = c.sf1.state_place_blockgroup('NAME', 'H034010'), 17, 14000)
 
 In addition to these convenient methods, there are three lower level ways to get census tracts, blocks, and groups for arbitrary geometries.
 
 ::
-    
+
     import json
-    
+
     with open('my_shape.geojson') as infile:
         my_shape_geojson = json.load(infile)
     features = []
@@ -64,9 +64,9 @@ In addition to these convenient methods, there are three lower level ways to get
     for tract_geojson, tract_data, tract_proportion in old_homes:
          tract_geojson['properties'].update(tract_data)
          features.append(tract)
-         
+
     my_shape_with_new_data_geojson = {'type': "FeatureCollection", 'features': features}
-    
+
 
 The method takes in the census variables you want and a geojson geometry, and returns a **generator** of the tract shapes, as geojson features, and the variables for that tract. Additionally, the generator returns a "tract proportion"; this is the proportion of the area of the tract that falls within your target shape.
 
@@ -74,11 +74,11 @@ Similar methods are provided for block groups and blocks, for the ACS 5-year and
 ::
 
     c.acs5.geo_blockgroup(('NAME', 'B25034_010E'), my_shape_geojson['geometry'])
-    
+
     c.sf1.geo_block(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
     c.sf1.geo_blockgroup(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
     c.sf1.geo_tract(('NAME', 'H016F0002'), my_shape_geojson['geometry'])
-    
+
     c.sf1.state_place_tract('NAME', 'H034010'), my_shape_geojson['geometry'])
     c.sf1.state_place_blockgroup('NAME', 'H034010'), my_shape_geojson['geometry'])
 

--- a/census_area/__init__.py
+++ b/census_area/__init__.py
@@ -40,8 +40,10 @@ class GeoClient(census.core.Client):
 
             tract_id = tract['properties']['TRACT']
             result = self.get(fields,
-                              {'for': 'tract:{}'.format(tract_id),
-                               'in':  within}, year, **kwargs)
+                              HashDict({'for': 'tract:{}'.format(tract_id),
+                                        'in': within}),
+                              year,
+                              **kwargs)
 
             if result:
                 result, = result
@@ -89,7 +91,14 @@ class GeoClient(census.core.Client):
                                            extra_query_args={'where': search_query,
                                                              'orderByFields': 'OID'})
 
-        place = next(iter(place_dumper))
+        try:
+            place = next(iter(place_dumper))
+        except TypeError as e:
+            if "'<' not supported between instances of 'NoneType' and 'NoneType'" in str(e):
+                raise ValueError(f'Could not find specified place "{place}" in state "{state}"')
+
+            raise e
+
         logging.info(place['properties']['NAME'])
         place_geojson = place['geometry']
 

--- a/census_area/core.py
+++ b/census_area/core.py
@@ -16,7 +16,7 @@ GEO_URLS = {
         2018: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2018/MapServer/8',
         2019: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2019/MapServer/8',
         2020: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2020/MapServer/6',
-        },
+    },
     'block groups': {
         2000: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2000/MapServer/10',
         2010: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Census2010/MapServer/16',
@@ -30,7 +30,7 @@ GEO_URLS = {
         2018: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2017/MapServer/10',
         2019: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2018/MapServer/10',
         2020: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2020/MapServer/8',
-        },
+    },
     'blocks': {
         2000: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2000/MapServer/12',
         2010: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2010/MapServer/14',
@@ -46,8 +46,8 @@ GEO_URLS = {
         2015: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2015/MapServer/26',
         2016: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2016/MapServer/26',
         2017: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2017/MapServer/26',
-        2018: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2017/MapServer/28',
-        2019: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2017/MapServer/26',
+        2018: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2018/MapServer/26',
+        2019: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2019/MapServer/26',
         2020: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2020/MapServer/26',
     }
 }

--- a/census_area/core.py
+++ b/census_area/core.py
@@ -47,7 +47,7 @@ GEO_URLS = {
         2016: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2016/MapServer/26',
         2017: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2017/MapServer/26',
         2018: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2017/MapServer/28',
-        2019: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2017/MapServer/28',
+        2019: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2017/MapServer/26',
         2020: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2020/MapServer/26',
     }
 }


### PR DESCRIPTION
# Description

This PR patches two issues preventing users from running the quick start example.

1. The specified map server for the 2019 ACS returned nulls for the min and max object IDs, causing the error reported in #12. I changed to a different map server, and things seem to be working. @fgregg – does this seem like the right call?
2. We're using `lru_cache` for `get` requests, but we forgot to cast the geo arg, which is a plain dictionary, to a hashable object for caching. I updated that line, too.

### Testing instructions

1. Check out this branch and, from inside the project dir, locally install `census_area`: `pip install -e requirements.txt`. 
2. Open an interactive Python shell and step through the example code from the README. Confirm you wind up with usable results, and no errors. 

Connects #12 