### PR TITLE
Pass year as kwarg, add support for 2021 and 2022 ACS5 geographies

### DIFF
--- a/census_area/core.py
+++ b/census_area/core.py
@@ -98,7 +98,7 @@ class GeoClient(census.core.Client):
         '''
         return self._state_place_area(self.geo_blockgroup, *args, **kwargs)
 
-    @supported_years(2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2000)
+    @supported_years(2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2000)
     def geo_tract(self, fields, geojson_geometry, year=None, **kwargs):
         '''
         Retrieve variable values for tracts intersecting with an arbitrary
@@ -141,7 +141,7 @@ class GeoClient(census.core.Client):
 
             yield tract, result, intersection_proportion
 
-    @supported_years(2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010)
+    @supported_years(2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010)
     def geo_blockgroup(self, fields, geojson_geometry, year=None, **kwargs):
         '''
         Retrieve variable values for block groups intersecting with an arbitrary
@@ -207,7 +207,7 @@ class GeoClient(census.core.Client):
         logging.info(place['properties']['NAME'])
         place_geojson = place['geometry']
 
-        areas = method(fields, place_geojson, year, **kwargs)
+        areas = method(fields, place_geojson, year=year, **kwargs)
 
         features = []
         for i, (feature, result, _) in enumerate(areas):
@@ -354,11 +354,11 @@ class ACS5Client(census.core.ACS5Client, GeoClient):
     Client to access American Community Survey 5-Year Estimates (see:
     https://www.census.gov/data/developers/data-sets/acs-5year.html)
     '''
-    @supported_years(2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010)
+    @supported_years(2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010)
     def state_place_tract(self, *args, **kwargs):
         return super().state_place_tract(*args, **kwargs)
 
-    @supported_years(2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010)
+    @supported_years(2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010)
     def state_place_blockgroup(self, *args, **kwargs):
         return super().state_place_blockgroup(*args, **kwargs)
 

--- a/census_area/variables.py
+++ b/census_area/variables.py
@@ -12,6 +12,8 @@ GEO_URLS = {
         2018: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2018/MapServer/8',
         2019: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2019/MapServer/8',
         2020: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2020/MapServer/6',
+        2021: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2021/MapServer/6',
+        2022: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2022/MapServer/6',
     },
     'block groups': {
         2000: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2000/MapServer/10',
@@ -26,6 +28,8 @@ GEO_URLS = {
         2018: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2017/MapServer/10',
         2019: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2018/MapServer/10',
         2020: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2020/MapServer/8',
+        2021: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2021/MapServer/8',
+        2022: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2022/MapServer/8',
     },
     'blocks': {
         2000: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2000/MapServer/12',
@@ -45,6 +49,8 @@ GEO_URLS = {
         2018: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2018/MapServer/26',
         2019: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2019/MapServer/26',
         2020: 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2020/tigerWMS_Census2020/MapServer/26',
+        2021: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2021/MapServer/24',
+        2022: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2022/MapServer/24',
     },
 }
 


### PR DESCRIPTION
## Description 

Supersedes #16.

This PR adds support for 2021 and 2022 ACS5 geographies and fixes a bug where the year kwarg was not passed on.